### PR TITLE
Add missing READMEs and refresh template index

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,9 @@
+# Ansible playbooks
+
+Use the bundled playbooks to provision software after your VM is created. The docker example installs Docker with Ansible in a single run:
+
+```
+onctl up -n ansible -a ansible/playbooks/docker.yaml
+```
+
+Add more playbooks under `ansible/playbooks/` to automate additional configuration tasks.

--- a/coder/README.md
+++ b/coder/README.md
@@ -1,0 +1,9 @@
+# Coder deployment
+
+Provision a VM with Docker and the Coder service ready to use:
+
+```
+onctl up -n coder -a coder/init.sh
+```
+
+The script installs Docker, creates the required users, and enables the `coder` systemd service so the UI is available after boot.

--- a/index.yaml
+++ b/index.yaml
@@ -51,22 +51,6 @@ templates:
   tags:
   - docker
   - container
-- name: frp
-  version: 1.0.0
-  description: Fast Reverse Proxy (FRP) client and server setup.
-  config: frp/frpc.sh
-  tags:
-  - frp
-  - proxy
-  - networking
-- name: harbor
-  version: 1.0.0
-  description: Harbor container registry deployment.
-  config: harbor/harbor.sh
-  tags:
-  - harbor
-  - registry
-  - container
 - name: k3s
   version: 1.0.0
   description: Deploys a K3s server instance.

--- a/minio/README.md
+++ b/minio/README.md
@@ -1,0 +1,15 @@
+# MinIO setup options
+
+Use Docker for a quick S3-compatible server:
+
+```
+onctl up -n minio -a minio/docker.sh
+```
+
+For a native installation using the official Debian package instead:
+
+```
+onctl up -n minio -a minio/minio.sh
+```
+
+Both scripts expose the MinIO API on port `9000` and the console on port `9001`.

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -1,0 +1,9 @@
+# Nginx installation
+
+Bring up a VM with Nginx installed and enabled:
+
+```
+onctl up -n nginx -a nginx/install.sh
+```
+
+The script updates apt packages, installs Nginx, and ensures the service starts on boot.

--- a/node/README.md
+++ b/node/README.md
@@ -1,0 +1,9 @@
+# Node.js with NVM
+
+Install Node.js using NVM and include PM2 for process management:
+
+```
+onctl up -n node -a node/node.sh
+```
+
+The script installs NVM, downloads Node.js v22, verifies npm, and adds the global `pm2` utility.

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,9 @@
+# Test template
+
+Use this template to validate environment variables passed to your VM:
+
+```
+onctl up -n test -a test/test.sh -e TEST_VAR=hello
+```
+
+The script echoes the `TEST_VAR` value along with the public IP so you can confirm parameter injection.


### PR DESCRIPTION
## Summary
- add README coverage for ansible, coder, minio, nginx, node, and test templates
- regenerate index.yaml to reflect existing template directories

## Testing
- python .github/scripts/generate_index.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694557fcc46c8322b26b8d77b77c3c64)