### PR TITLE
Add rustfs configuration template

### DIFF
--- a/.github/scripts/generate_index.py
+++ b/.github/scripts/generate_index.py
@@ -85,6 +85,11 @@ TEMPLATE_CONFIGS = {
         'preferred_script': 'harbor.sh',
         'description': 'Harbor container registry deployment.',
         'tags': ['harbor', 'registry', 'container']
+    },
+    'rustfs': {
+        'preferred_script': 'rustfs.sh',
+        'description': 'Deploys RustFS object storage using the official Docker image.',
+        'tags': ['rustfs', 'object-storage', 's3']
     }
 }
 

--- a/index.yaml
+++ b/index.yaml
@@ -100,6 +100,14 @@ templates:
   - rke2
   - kubernetes
   - rancher
+- name: rustfs
+  version: 1.0.0
+  description: Deploys RustFS object storage using the official Docker image.
+  config: rustfs/rustfs.sh
+  tags:
+  - rustfs
+  - object-storage
+  - s3
 - name: wireguard
   version: 1.0.0
   description: Configures WireGuard VPN server.

--- a/rustfs/README.md
+++ b/rustfs/README.md
@@ -1,0 +1,17 @@
+# RustFS on Docker
+
+This template deploys [RustFS](https://rustfs.com/) using the official Docker image. It installs Docker when required, prepares data/log directories with the correct UID for the container (10001), and runs RustFS with ports 9000 (S3 API) and 9001 (console) exposed.
+
+## Usage
+
+```bash
+# Optional: set a specific version and custom data/log paths
+export RUSTFS_VERSION=1.0.0-alpha.76
+export DATA_DIR=/opt/rustfs/data
+export LOG_DIR=/opt/rustfs/logs
+
+# Run the installer
+./rustfs.sh
+```
+
+The container is started with `--restart unless-stopped`. If an existing `rustfs` container is found it will be replaced so new configuration takes effect.

--- a/rustfs/rustfs.sh
+++ b/rustfs/rustfs.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+
+RUSTFS_VERSION=${RUSTFS_VERSION:-latest}
+DATA_DIR=${DATA_DIR:-/opt/rustfs/data}
+LOG_DIR=${LOG_DIR:-/opt/rustfs/logs}
+
+install_docker() {
+  echo "Installing Docker..."
+  apt-get update
+  apt-get install -y ca-certificates curl gnupg lsb-release
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  chmod a+r /etc/apt/keyrings/docker.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+    > /etc/apt/sources.list.d/docker.list
+  apt-get update
+  apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+}
+
+ensure_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    install_docker
+  fi
+}
+
+prepare_directories() {
+  mkdir -p "$DATA_DIR" "$LOG_DIR"
+  chown -R 10001:10001 "$DATA_DIR" "$LOG_DIR"
+}
+
+start_rustfs() {
+  if docker ps -a --format '{{.Names}}' | grep -q '^rustfs$'; then
+    echo "Existing rustfs container found. Restarting with current configuration."
+    docker rm -f rustfs >/dev/null 2>&1 || true
+  fi
+
+  docker run -d \
+    --name rustfs \
+    -p 9000:9000 \
+    -p 9001:9001 \
+    -v "$DATA_DIR:/data" \
+    -v "$LOG_DIR:/logs" \
+    --restart unless-stopped \
+    rustfs/rustfs:"$RUSTFS_VERSION"
+}
+
+main() {
+  ensure_docker
+  prepare_directories
+  start_rustfs
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a RustFS template that installs Docker if needed and runs the official container with prepared data/log directories
- document the RustFS template usage and defaults
- register RustFS in the index generator and regenerate `index.yaml`

## Testing
- python .github/scripts/generate_index.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69455a24901883228c0167982a458531)