### PR TITLE
feat: add github-runner template for ephemeral GitHub Actions runners

### DIFF
--- a/.github/scripts/generate_index.py
+++ b/.github/scripts/generate_index.py
@@ -95,6 +95,11 @@ TEMPLATE_CONFIGS = {
         'preferred_script': 'supabase.sh',
         'description': 'Self-hosted Supabase backend-as-a-service (Postgres, Auth, Storage, Realtime, Studio).',
         'tags': ['supabase', 'postgres', 'backend', 'database', 'auth']
+    },
+    'github-runner': {
+        'preferred_script': 'github-runner.sh',
+        'description': 'Registers an ephemeral self-hosted GitHub Actions runner.',
+        'tags': ['github', 'github-actions', 'ci', 'runner']
     }
 }
 

--- a/github-runner/README.md
+++ b/github-runner/README.md
@@ -1,0 +1,32 @@
+# GitHub Actions self-hosted runner
+
+Registers an ephemeral self-hosted GitHub Actions runner on the VM. The runner
+picks up exactly one job, then deregisters itself.
+
+## run vm + install docker + register runner
+
+```
+TOKEN=$(gh api -X POST repos/<owner>/<repo>/actions/runners/registration-token -q .token)
+onctl up -n runner -a docker/docker.sh -a github-runner/github-runner.sh \
+  -e GH_REPO=<owner>/<repo> -e RUNNER_TOKEN=$TOKEN
+```
+
+Registration tokens expire after 1 hour — generate one right before `onctl up`.
+
+## use it in a workflow
+
+```yaml
+jobs:
+  build:
+    runs-on: [self-hosted, onctl]
+```
+
+Set `RUNNER_LABELS` (default `onctl`) to add custom comma-separated labels.
+
+## cleanup
+
+The runner deregisters itself after one job. Destroy the VM once it's done:
+
+```
+onctl destroy runner
+```

--- a/github-runner/github-runner.sh
+++ b/github-runner/github-runner.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -ex
+
+: "${GH_REPO:?GH_REPO (owner/repo) is required}"
+: "${RUNNER_TOKEN:?RUNNER_TOKEN is required}"
+RUNNER_LABELS="${RUNNER_LABELS:-onctl}"
+RUNNER_USER=runner
+RUNNER_HOME=/opt/actions-runner
+
+apt-get update
+apt-get install -y curl jq tar
+
+if ! id "$RUNNER_USER" >/dev/null 2>&1; then
+  useradd -m -s /bin/bash "$RUNNER_USER"
+fi
+getent group docker >/dev/null 2>&1 && usermod -aG docker "$RUNNER_USER" || true
+
+case "$(uname -m)" in
+  x86_64) ARCH=x64 ;;
+  aarch64) ARCH=arm64 ;;
+  *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+esac
+
+VERSION=$(curl -fsSL https://api.github.com/repos/actions/runner/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+mkdir -p "$RUNNER_HOME"
+curl -fsSL "https://github.com/actions/runner/releases/download/v${VERSION}/actions-runner-linux-${ARCH}-${VERSION}.tar.gz" | tar xz -C "$RUNNER_HOME"
+chown -R "$RUNNER_USER:$RUNNER_USER" "$RUNNER_HOME"
+
+sudo -u "$RUNNER_USER" "$RUNNER_HOME/config.sh" \
+  --url "https://github.com/${GH_REPO}" \
+  --token "$RUNNER_TOKEN" \
+  --name "$(hostname)" \
+  --labels "$RUNNER_LABELS" \
+  --ephemeral \
+  --unattended
+
+cd "$RUNNER_HOME"
+./svc.sh install "$RUNNER_USER"
+./svc.sh start

--- a/index.yaml
+++ b/index.yaml
@@ -51,6 +51,15 @@ templates:
   tags:
   - docker
   - container
+- name: github-runner
+  version: 1.0.0
+  description: Registers an ephemeral self-hosted GitHub Actions runner.
+  config: github-runner/github-runner.sh
+  tags:
+  - github
+  - github-actions
+  - ci
+  - runner
 - name: hcloud
   version: 1.0.0
   description: Configuration and setup scripts for hcloud.


### PR DESCRIPTION
## Summary
- Adds a `github-runner` template: registers an ephemeral self-hosted GitHub Actions runner (`config.sh --ephemeral`), meant to be composed with `docker/docker.sh`
- Registers the template in `generate_index.py` and adds the corresponding `index.yaml` entry

## Test plan
- [x] `shellcheck` clean on `github-runner/github-runner.sh`
- [x] `validate_index.py` passes
- [ ] Manual: `onctl up -a docker/docker.sh -a github-runner/github-runner.sh -e GH_REPO=... -e RUNNER_TOKEN=...` registers a runner and picks up a workflow job