### PR TITLE
feat: add github-runner-jit template for ephemeral GitHub Actions runners

### DIFF
--- a/.github/scripts/generate_index.py
+++ b/.github/scripts/generate_index.py
@@ -95,6 +95,11 @@ TEMPLATE_CONFIGS = {
         'preferred_script': 'supabase.sh',
         'description': 'Self-hosted Supabase backend-as-a-service (Postgres, Auth, Storage, Realtime, Studio).',
         'tags': ['supabase', 'postgres', 'backend', 'database', 'auth']
+    },
+    'github-runner-jit': {
+        'preferred_script': 'github-runner-jit.sh',
+        'description': 'Registers an ephemeral self-hosted GitHub Actions runner using a just-in-time (JIT) config.',
+        'tags': ['github', 'github-actions', 'ci', 'runner', 'jit']
     }
 }
 

--- a/github-runner-jit/README.md
+++ b/github-runner-jit/README.md
@@ -1,0 +1,40 @@
+# GitHub Actions self-hosted runner (JIT config)
+
+Registers an ephemeral self-hosted GitHub Actions runner on the VM using a
+just-in-time (JIT) runner config — a single-use, pre-scoped credential
+generated *before* the VM exists, so no registration token or other reusable
+credential ever touches the VM. The runner picks up exactly one job, then
+exits.
+
+## generate JIT config + run vm
+
+```
+JIT_CONFIG=$(gh api -X POST repos/<owner>/<repo>/actions/runners/generate-jitconfig \
+  -f name=runner-jit -F runner_group_id=1 \
+  -f 'labels[]=self-hosted' -f 'labels[]=onctl' \
+  -q .encoded_jit_config)
+onctl up -n runner-jit -a github-runner-jit/github-runner-jit.sh -e JIT_CONFIG=$JIT_CONFIG
+```
+
+Generating the JIT config requires a token with `administration:write` on the
+repo (classic PAT with `repo` scope, or fine-grained PAT with
+Administration: Read & write).
+
+`SKIP_DOCKER=1` (via `-e`) skips the docker install step.
+
+## use it in a workflow
+
+```yaml
+jobs:
+  build:
+    runs-on: [self-hosted, onctl]
+```
+
+## cleanup
+
+The runner process exits after one job — no `config.sh`, no systemd service,
+no reusable credential left on the VM. Destroy the VM once it's done:
+
+```
+onctl destroy runner-jit
+```

--- a/github-runner-jit/github-runner-jit.sh
+++ b/github-runner-jit/github-runner-jit.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Bootstrap a GitHub Actions runner via JIT config on a fresh Ubuntu VM.
+# Designed to run as root via `onctl create -a` / `onctl up -a`.
+#
+# Required vars (pass with -e):
+#   JIT_CONFIG    base64 JIT config blob, generate with:
+#                 gh api -X POST repos/$GH_REPO/actions/runners/generate-jitconfig \
+#                   -f name=runner-spike-jit -F runner_group_id=1 \
+#                   -f 'labels[]=self-hosted' -f 'labels[]=onctl' \
+#                   -q .encoded_jit_config
+# Optional vars:
+#   SKIP_DOCKER   set to 1 to skip docker install (faster boot measurement)
+set -euo pipefail
+
+T0=$(date +%s)
+say() { echo "[github-runner-jit +$(($(date +%s) - T0))s] $*"; }
+
+JIT_CONFIG="${JIT_CONFIG:?JIT_CONFIG is required, pass with -e JIT_CONFIG=...}"
+RUNNER_USER=runner
+RUNNER_HOME=/opt/actions-runner
+
+say "installing packages"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq curl jq git tar >/dev/null
+
+if [ "${SKIP_DOCKER:-0}" != "1" ]; then
+    say "installing docker"
+    curl -fsSL https://get.docker.com | sh >/dev/null 2>&1
+fi
+
+say "creating ${RUNNER_USER} user"
+if ! id "$RUNNER_USER" >/dev/null 2>&1; then
+    useradd -m -s /bin/bash "$RUNNER_USER"
+fi
+getent group docker >/dev/null 2>&1 && usermod -aG docker "$RUNNER_USER"
+
+say "downloading actions-runner"
+case "$(uname -m)" in
+    x86_64) ARCH=x64 ;;
+    aarch64) ARCH=arm64 ;;
+    *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+esac
+VERSION=$(curl -fsSL https://api.github.com/repos/actions/runner/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+mkdir -p "$RUNNER_HOME"
+curl -fsSL "https://github.com/actions/runner/releases/download/v${VERSION}/actions-runner-linux-${ARCH}-${VERSION}.tar.gz" \
+    | tar xz -C "$RUNNER_HOME"
+chown -R "$RUNNER_USER:$RUNNER_USER" "$RUNNER_HOME"
+
+say "starting runner via JIT config in background (ephemeral: exits after one job)"
+cd "$RUNNER_HOME"
+sudo -u "$RUNNER_USER" bash -c "nohup ./run.sh --jitconfig '$JIT_CONFIG' > '$RUNNER_HOME/jit-run.log' 2>&1 &"
+
+say "runner launched, no service installed"

--- a/index.yaml
+++ b/index.yaml
@@ -51,6 +51,16 @@ templates:
   tags:
   - docker
   - container
+- name: github-runner-jit
+  version: 1.0.0
+  description: Registers an ephemeral self-hosted GitHub Actions runner using a just-in-time (JIT) config.
+  config: github-runner-jit/github-runner-jit.sh
+  tags:
+  - github
+  - github-actions
+  - ci
+  - runner
+  - jit
 - name: hcloud
   version: 1.0.0
   description: Configuration and setup scripts for hcloud.


### PR DESCRIPTION
## Summary
- Adds a JIT-config variant of the github-runner template (companion to #24): generates a single-use runner config (`generate-jitconfig`) before the VM exists, so no registration token or other reusable credential ever touches the VM.
- Validated end-to-end against `cdalar/onctl-runner-test` (provision ~1m, pickup ~3s, runner self-exits after one job, no leftover systemd service).

## Test plan
- [x] `python3 .github/scripts/generate_index.py` output matches manual `index.yaml` edit (verified by inspection, pyyaml unavailable in this env)
- [x] Reviewed `index.yaml` entry ordering (alphabetical, matches existing convention)