### PR TITLE
feat(firecracker): add IP forwarding and NAT for microVM internet access

### DIFF
--- a/firecracker/firecracker-host-setup.sh
+++ b/firecracker/firecracker-host-setup.sh
@@ -42,24 +42,32 @@ curl -fsSL "https://s3.amazonaws.com/spec.ccfc.min/${rootfs_key}" -o rootfs.ext4
 
 # Enable IP forwarding and NAT so microVMs can reach the internet.
 HOST_IFACE=$(ip route show default | awk '/default/ {print $5; exit}')
+if [ -z "${HOST_IFACE}" ]; then
+  echo "error: could not determine default outbound interface — no default route found" >&2
+  exit 1
+fi
 
-# Persist IP forwarding across reboots
+# The onctl FC provider assigns microVMs IPs in this subnet.
+FC_CIDR="172.16.0.0/24"
+
+# Persist IP forwarding across reboots.
 echo 'net.ipv4.ip_forward=1' > /etc/sysctl.d/99-firecracker.conf
 sysctl -p /etc/sysctl.d/99-firecracker.conf
 
-# NAT: masquerade microVM traffic (any tap+ device) through the host's default interface
-iptables -t nat -C POSTROUTING -o "${HOST_IFACE}" -j MASQUERADE 2>/dev/null \
-  || iptables -t nat -A POSTROUTING -o "${HOST_IFACE}" -j MASQUERADE
+# NAT: masquerade only FC subnet traffic through the host's default interface.
+iptables -t nat -C POSTROUTING -s "${FC_CIDR}" -o "${HOST_IFACE}" -j MASQUERADE 2>/dev/null \
+  || iptables -t nat -A POSTROUTING -s "${FC_CIDR}" -o "${HOST_IFACE}" -j MASQUERADE
 
-# Allow forwarding for return traffic (established/related connections)
-iptables -C FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2>/dev/null \
-  || iptables -A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+# Allow outbound forwarding from the FC subnet to the internet.
+# Insert at position 1 so these rules are evaluated before any catch-all DROP rules.
+iptables -C FORWARD -s "${FC_CIDR}" -o "${HOST_IFACE}" -j ACCEPT 2>/dev/null \
+  || iptables -I FORWARD 1 -s "${FC_CIDR}" -o "${HOST_IFACE}" -j ACCEPT
 
-# Allow forwarding from tap devices to the host interface
-iptables -C FORWARD -i tap+ -o "${HOST_IFACE}" -j ACCEPT 2>/dev/null \
-  || iptables -A FORWARD -i tap+ -o "${HOST_IFACE}" -j ACCEPT
+# Allow return (RELATED,ESTABLISHED) traffic back to the FC subnet only.
+iptables -C FORWARD -d "${FC_CIDR}" -i "${HOST_IFACE}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2>/dev/null \
+  || iptables -I FORWARD 1 -d "${FC_CIDR}" -i "${HOST_IFACE}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 
-# Persist iptables rules across reboots
+# Persist iptables rules across reboots.
 mkdir -p /etc/iptables
 iptables-save > /etc/iptables/rules.v4
 

--- a/firecracker/firecracker-host-setup.sh
+++ b/firecracker/firecracker-host-setup.sh
@@ -5,7 +5,8 @@ set -ex
 # to run Firecracker microVMs via `ONCTL_CLOUD=firecracker onctl ...`.
 
 apt-get update
-apt-get install -y curl iproute2 e2fsprogs
+apt-get install -y curl iproute2 e2fsprogs iptables
+DEBIAN_FRONTEND=noninteractive apt-get install -y iptables-persistent
 
 if [ -e /dev/kvm ]; then
   echo "/dev/kvm is available"
@@ -38,6 +39,29 @@ rootfs_key=$(curl -fsSL "https://s3.amazonaws.com/spec.ccfc.min/?prefix=firecrac
   | grep -oP "(?<=<Key>)(firecracker-ci/${CI_VERSION}/${ARCH}/ubuntu-22\.04\.ext4)(?=</Key>)" \
   | sort -V | tail -1)
 curl -fsSL "https://s3.amazonaws.com/spec.ccfc.min/${rootfs_key}" -o rootfs.ext4
+
+# Enable IP forwarding and NAT so microVMs can reach the internet.
+HOST_IFACE=$(ip route show default | awk '/default/ {print $5; exit}')
+
+# Persist IP forwarding across reboots
+echo 'net.ipv4.ip_forward=1' > /etc/sysctl.d/99-firecracker.conf
+sysctl -p /etc/sysctl.d/99-firecracker.conf
+
+# NAT: masquerade microVM traffic (any tap+ device) through the host's default interface
+iptables -t nat -C POSTROUTING -o "${HOST_IFACE}" -j MASQUERADE 2>/dev/null \
+  || iptables -t nat -A POSTROUTING -o "${HOST_IFACE}" -j MASQUERADE
+
+# Allow forwarding for return traffic (established/related connections)
+iptables -C FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2>/dev/null \
+  || iptables -A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+
+# Allow forwarding from tap devices to the host interface
+iptables -C FORWARD -i tap+ -o "${HOST_IFACE}" -j ACCEPT 2>/dev/null \
+  || iptables -A FORWARD -i tap+ -o "${HOST_IFACE}" -j ACCEPT
+
+# Persist iptables rules across reboots
+mkdir -p /etc/iptables
+iptables-save > /etc/iptables/rules.v4
 
 # Install onctl itself so microVMs can be managed from this host.
 curl -sLS https://docs.onctl.io/get.sh | bash


### PR DESCRIPTION
## Summary

- Installs `iptables` and `iptables-persistent` on the host
- Enables `net.ipv4.ip_forward=1` persistently via `/etc/sysctl.d/99-firecracker.conf`
- Adds iptables NAT masquerade rule on the host's default outbound interface so microVM traffic is translated to the host IP
- Adds FORWARD rules to allow outbound tap→host traffic and return (RELATED,ESTABLISHED) traffic
- Persists all rules to `/etc/iptables/rules.v4` via `iptables-save` (loaded on boot by `netfilter-persistent`)
- Rules use `-C` (check) before `-A` (append) to be idempotent on re-runs

## Test plan

- [ ] Run `firecracker-host-setup.sh` on a fresh GCP VM with nested virt enabled
- [ ] Verify `sysctl net.ipv4.ip_forward` returns `1`
- [ ] Verify `iptables -t nat -L POSTROUTING` shows the MASQUERADE rule
- [ ] Create a microVM with `ONCTL_CLOUD=firecracker onctl create` and confirm `curl https://example.com` works from inside the VM
- [ ] Reboot the host and verify the iptables rules are still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiVULi3n7Ty2U2L1NbBrXi